### PR TITLE
Fix variadic logger wrapper calls to compile on current Go version

### DIFF
--- a/custom/cache/check.go
+++ b/custom/cache/check.go
@@ -99,19 +99,19 @@ type DefaultLogger struct {
 }
 
 func (this *DefaultLogger) Debugf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Infof(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Warnf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Errorf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Debug(v ...interface{}) {

--- a/helloworld/check.go
+++ b/helloworld/check.go
@@ -60,19 +60,19 @@ type DefaultLogger struct {
 }
 
 func (this *DefaultLogger) Debugf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Infof(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Warnf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Errorf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Debug(v ...interface{}) {

--- a/multi/appid/check.go
+++ b/multi/appid/check.go
@@ -58,19 +58,19 @@ type DefaultLogger struct {
 }
 
 func (this *DefaultLogger) Debugf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Infof(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Warnf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Errorf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Debug(v ...interface{}) {

--- a/multi/namespace/check.go
+++ b/multi/namespace/check.go
@@ -41,19 +41,19 @@ type DefaultLogger struct {
 }
 
 func (this *DefaultLogger) Debugf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Infof(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Warnf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Errorf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Debug(v ...interface{}) {

--- a/web/check.go
+++ b/web/check.go
@@ -95,19 +95,19 @@ type DefaultLogger struct {
 }
 
 func (this *DefaultLogger) Debugf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Infof(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Warnf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Errorf(format string, params ...interface{}) {
-	this.Debug(format, params...)
+	this.Debug(append([]interface{}{format}, params...)...)
 }
 
 func (this *DefaultLogger) Debug(v ...interface{}) {


### PR DESCRIPTION
### Motivation
- The project failed to build because `DefaultLogger` wrappers forwarded variadic arguments incorrectly (`this.Debug(format, params...)`) which is not valid for forwarding to `Debug(...interface{})` on the current Go toolchain.

### Description
- Updated `Debugf`, `Infof`, `Warnf`, and `Errorf` in all demo `DefaultLogger` implementations to forward arguments using `this.Debug(append([]interface{}{format}, params...)...)` so the format string and parameters are passed as a single variadic slice.
- Files modified: `custom/cache/check.go`, `helloworld/check.go`, `multi/appid/check.go`, `multi/namespace/check.go`, and `web/check.go`.

### Testing
- Ran `go test ./...` which previously failed during build, and the run completed successfully with all packages building (packages report `[no test files]` where applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53bbcabf883249efcb832ecf94e23)